### PR TITLE
Fix yahoo.com leaking and banning

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -1,9 +1,11 @@
-﻿<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <addon id="metadata.movie.stupid" name="Stupid Movie Scraper" version="1.1.0" provider-name="mrjwm2">
   <requires>
     <import addon="xbmc.metadata" version="2.1.0" />
+    <import addon="xbmc.python" version="2.1.0"/>
   </requires>
   <extension point="xbmc.metadata.scraper.movies" language="en" library="stupid.xml" />
+  <extension point="xbmc.service" library="service.py" start="login" />
   <extension point="xbmc.addon.metadata">
     <summary lang="en">Stupid Movie Scraper</summary>
     <description lang="en">This scraper adds video by filename only.</description>

--- a/addon.xml
+++ b/addon.xml
@@ -3,6 +3,8 @@
   <requires>
     <import addon="xbmc.metadata" version="2.1.0" />
     <import addon="xbmc.python" version="2.1.0"/>
+    <import addon="script.module.six" version="1.9.0"/>
+    <import addon="script.module.httpd-echo" version="0.1"/>
   </requires>
   <extension point="xbmc.metadata.scraper.movies" language="en" library="stupid.xml" />
   <extension point="xbmc.service" library="service.py" start="login" />

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,2 +1,5 @@
+v1.2.0 (2016-9-10) 
+RELEASE: Switch from yahoo.com to a local echo server to stub out queries
+
 v1.1.0 (2016-2-3) 
 RELEASE: Scrapes <title>

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<settings>
+  <setting label="Port" type="number" id="port"
+           default="8000" range="1025,65535" />
+</settings>

--- a/service.py
+++ b/service.py
@@ -1,0 +1,44 @@
+"""
+Start the echo server on login.
+"""
+
+import sys
+import os
+import threading
+
+from six.moves import BaseHTTPServer
+
+import xbmc
+import xbmcaddon
+
+sys.path.append(os.path.join(os.path.dirname(__file__), 'httpd-echo'))
+import httpdecho  # noqa
+
+ADDON = xbmcaddon.Addon()
+
+
+def main():
+    """
+    Start the echo server on login.
+    """
+
+    httpd = BaseHTTPServer.HTTPServer(
+        ('localhost', int(ADDON.getSetting("port"))),
+        httpdecho.EchoHTTPRequestHandler)
+    httpd_thread = threading.Thread(target=httpd.serve_forever)
+    httpd_thread.start()
+
+    monitor = xbmc.Monitor()
+ 
+    while not monitor.abortRequested():
+        # Sleep/wait for abort for 10 seconds
+        if monitor.waitForAbort(10):
+            # Abort was requested while waiting. We should exit
+            break
+
+    httpd.shutdown()
+    httpd.server_close()
+
+
+if __name__ == '__main__':
+    main()

--- a/service.py
+++ b/service.py
@@ -17,6 +17,36 @@ import httpdecho  # noqa
 ADDON = xbmcaddon.Addon()
 
 
+class StupidHTTPRequestHandler(httpdecho.EchoHTTPRequestHandler):
+    httpdecho.EchoHTTPRequestHandler.__doc__
+
+    log_level = xbmc.LOGDEBUG
+
+    def _log(self, format, args, level=None):
+        """
+        Common logging system call.
+        """
+        if level is None:
+            level = self.log_level
+        xbmc.log(
+            "metadata.movie.stupid: %s - - [%s] %s\n" % (
+                self.client_address[0], self.log_date_time_string(),
+                format % args),
+            level)
+
+    def log_message(self, format, *args):
+        """
+        Send log messages to the logging module instead of stderr.
+        """
+        self._log(format, args)
+
+    def log_error(self, format, *args):
+        """
+        Log at the correct level.
+        """
+        self.log_message(format, args, level=xbmc.LOGERROR)
+
+
 def main():
     """
     Start the echo server on login.
@@ -24,7 +54,7 @@ def main():
 
     httpd = BaseHTTPServer.HTTPServer(
         ('localhost', int(ADDON.getSetting("port"))),
-        httpdecho.EchoHTTPRequestHandler)
+        StupidHTTPRequestHandler)
     httpd_thread = threading.Thread(target=httpd.serve_forever)
     httpd_thread.start()
 

--- a/stupid.xml
+++ b/stupid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <scraper name="Stupid Movie Database" content="movies" thumb="icon.png" framework="1.1" language="en">
     <CreateSearchUrl dest="3" clearbuffers="no">
-        <RegExp dest="3" output="&lt;url&gt;http://search.yahoo.com/search?p=$$7&lt;/url&gt;" input="$$7">
+        <RegExp dest="3" output="&lt;url&gt;http://localhost:8000/?filename=$$7&lt;/url&gt;" input="$$7">
             <RegExp dest="7" output="\1" input="$$1">
                 <expression noclean="1" trim="1">(.+)</expression>
             </RegExp>
@@ -10,8 +10,8 @@
     </CreateSearchUrl>
     <GetSearchResults dest="8" clearbuffers="no">
         <RegExp dest="8" output="&lt;results sorted=&quot;yes&quot;&gt;\1&lt;/results&gt;" input="$$5">
-            <RegExp dest="5" output="&lt;entity&gt;&lt;title&gt;\1&lt;/title&gt;&lt;url&gt;http://search.yahoo.com/search?p=$$7&lt;/url&gt;&lt;/entity&gt;" input="$$1">
-                <expression noclean="1" trim="1">&lt;title&gt;([^"]*)\-\sYahoo Search</expression>
+            <RegExp dest="5" output="&lt;entity&gt;&lt;title&gt;\1&lt;/title&gt;&lt;url&gt;http://localhost:8000/?filename=$$7&lt;/url&gt;&lt;/entity&gt;" input="$$1">
+                <expression noclean="1" trim="1">filename: (.*)</expression>
             </RegExp>
             <expression noclean="1"></expression>
         </RegExp>
@@ -19,7 +19,7 @@
     <GetDetails dest="3" clearbuffers="no">
         <RegExp dest="3" output="&lt;details&gt;\1&lt;/details&gt;" input="$$5">
             <RegExp dest="5+" output="&lt;title&gt;\1&lt;/title&gt;" input="$$1">
-                <expression noclean="1" trim="1">&lt;title&gt;(.+)\s\-\sYahoo Search Results&lt;/title&gt;</expression>
+                <expression noclean="1" trim="1">filename: (.*)</expression>
             </RegExp>
             <expression noclean="1" trim="1"></expression>
         </RegExp>


### PR DESCRIPTION
Switch to using a local HTTP echo server in a Python service.

Because Kodi is hard coded to either scrape only from local *.nfo files
or from an internet source, this addon used to just query
http://search.yahoo.com just to get the query echoed in the HTML title
element.  This has several problems, chief among them:
1. It leaks library filenames to a 3rd party
2. IP will get banned with a large collection of files

Using a local HTTP echo server is less than ideal, but I don't know
enough CPP, let alone enough of Kodi's internals to do this the right
way: a simple source setting to fallback to the title if no scrape is
successful.

This is a re-submission of #1 but with Python dependencies done the Kodi/XBMC way.  As such, installing this addon also requires installing [script.module.httpd-echo](https://github.com/rpatterson/script.module.httpd-echo)
